### PR TITLE
interpolation fixed for flat_key lookups

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -17,7 +17,7 @@ module GettextI18nRails
       flat_key = flatten_key key, options
       if FastGettext.key_exist?(flat_key)
         raise "no yet build..." if options[:locale]
-        _(flat_key)
+        (_(flat_key) %options)
       else
         if self.class.translate_defaults
           [*options[:default]].each do |default|


### PR DESCRIPTION
Hi,

Noticed that my lookups from my I18n.t existing calls in my app were not performing interpolation of variables.  This fixes it.

m
