### PR TITLE
patch to handle ruby 1.9 hashes

### DIFF
--- a/lib/gettext_i18n_rails/ruby_gettext_extractor.rb
+++ b/lib/gettext_i18n_rails/ruby_gettext_extractor.rb
@@ -47,7 +47,8 @@ module RubyGettextExtractor
       # ruby parser has an ugly bug which causes that several \000's take
       # ages to parse. This avoids this probelm by stripping them away (they probably wont appear in keys anyway)
       # See bug report: http://rubyforge.org/tracker/index.php?func=detail&aid=26898&group_id=439&atid=1778
-      safe_content = content.gsub(/\\\d\d\d/, '')
+      # also support new ruby 1.9 hashes, derived from http://www.ruby-forum.com/topic/202257#881704
+      safe_content = content.gsub(/\\\d\d\d/, '').gsub(/(\w+):\s+/, ':\1 =>')
       self.parse(safe_content)
       return @results
     end


### PR DESCRIPTION
Not the nicest fix, but it seems that adapting ruby_parser to 1.9 is more difficult. Without a patch like this, the user only gets a non-descriptive error message for perfectly valid code:

<pre>
$ rake gettext:find
Error parsing app/views/home/terms.html.haml
rake aborted!

parse error on value ":" (tCOLON)

Tasks: TOP => gettext:find
</pre>
