### PR TITLE
Add missing dependency on ruby_parser

### DIFF
--- a/gettext_i18n_rails.gemspec
+++ b/gettext_i18n_rails.gemspec
@@ -49,11 +49,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<fast_gettext>, [">= 0"])
+      s.add_dependency(%q<ruby_parser>, [">= 0"])
     else
       s.add_dependency(%q<fast_gettext>, [">= 0"])
+      s.add_dependency(%q<ruby_parser>, [">= 0"])
     end
   else
     s.add_dependency(%q<fast_gettext>, [">= 0"])
+    s.add_dependency(%q<ruby_parser>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
- RubyGettextExtractor used by Haml parser depends on ruby_parser gem but this dependency is not listed in .gemspec. This makes `rake gettext:find` task fail if there are .haml files in a project.
- Added as a normal (non-runtime) dependency since this is only needed by rake tasks.

ruby_parser: https://github.com/seattlerb/ruby_parser

This fixes one of the bugs that prevent `gettext:find` from working with my application and original gettext.
