### PR TITLE
Make model_attributes_finder.rb work with (most) namespaced models

### DIFF
--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -6,20 +6,20 @@ module GettextI18nRails
       File.open(file,'w') do |f|
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
         ModelAttributesFinder.new.find(options).each do |table_name,column_names|
-        #model name
-        model = table_name_to_namespaced_model(table_name)
-        if model == nil
-          # Some tables are not models, for example: translation tables created by globalize2.
-          puts "[Warning] Model not found for table '#{table_name}'"
-          next
-        end
-        f.puts("_('#{model.human_name_without_translation}')")
+          #model name
+          model = table_name_to_namespaced_model(table_name)
+          if model == nil
+            # Some tables are not models, for example: translation tables created by globalize2.
+            puts "[Warning] Model not found for table '#{table_name}'"
+            next
+          end
+          f.puts("_('#{model.human_name_without_translation}')")
 
-        #all columns namespaced under the model
-        column_names.each do |attribute|
-          translation = model.gettext_translation_for_attribute_name(attribute)
-          f.puts("_('#{translation}')")
-        end
+          #all columns namespaced under the model
+          column_names.each do |attribute|
+            translation = model.gettext_translation_for_attribute_name(attribute)
+            f.puts("_('#{translation}')")
+          end
         end
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
       end


### PR DESCRIPTION
`rake gettext:store_model_attributes` does not find namespaced models. The table name -> model conversion is actually ambiguous if we allow namespaces, but with some reasonable assumptions it can be done most of the time. This patch makes it work with models nested at most one level deep.

This is a simple fix. A better one would be to stop trying to convert table names to model names (which is not possible to do reliably in a general case) and enumerate descendants of `ActiveRecord::Base` instead (using `ActiveRecord::Base.descendants()`). It, however, requires forcing Rails to preload all model classes at startup. This method would also include models defined by gems which may be desired in some cases and not in the others - there should be an option to filter them out.
