### PR TITLE
Make msgmerge configurable and better defaults

### DIFF
--- a/lib/gettext_i18n_rails/railtie.rb
+++ b/lib/gettext_i18n_rails/railtie.rb
@@ -2,6 +2,8 @@
 if defined?(Rails::Railtie)
   module GettextI18nRails
     class Railtie < ::Rails::Railtie
+      config.gettext_i18n_rails = ActiveSupport::OrderedOptions.new
+      config.gettext_i18n_rails.msgmerge = %w[--sort-output --no-location --no-wrap]
       rake_tasks do
         require 'gettext_i18n_rails/tasks'
       end

--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -23,7 +23,7 @@ namespace :gettext do
         files_to_translate,
         "version 0.0.1",
         :po_root => locale_path,
-        :msgmerge=>['--sort-output']
+        :msgmerge=> Rails.application.config.gettext_i18n_rails.msgmerge
       )
     else #we are on a version < 2.0
       puts "install new GetText with gettext:install to gain more features..."


### PR DESCRIPTION
--no-location is better for source control, as line number changes are
not constantly being marked as changes in .po files

--no-wrap mac/linux have a 1 char different default width, so this
ensures no changes when finding on different systems
