### PR TITLE
Optional translation of activerecord attributes

### DIFF
--- a/lib/gettext_i18n_rails.rb
+++ b/lib/gettext_i18n_rails.rb
@@ -22,6 +22,6 @@ require 'gettext_i18n_rails/backend'
 I18n.backend = GettextI18nRails::Backend.new
 
 require 'gettext_i18n_rails/i18n_hacks'
-require 'gettext_i18n_rails/active_record' if defined?(ActiveRecord)
+require 'gettext_i18n_rails/active_record'
 require 'gettext_i18n_rails/action_controller' if defined?(ActionController) # so that bundle console can work in a rails project
 require 'gettext_i18n_rails/railtie'

--- a/lib/gettext_i18n_rails/active_record.rb
+++ b/lib/gettext_i18n_rails/active_record.rb
@@ -1,21 +1,21 @@
-class ActiveRecord::Base
+module GettextI18nRails::ActiveRecord
   # CarDealer.sales_count -> s_('CarDealer|Sales count') -> 'Sales count' if no translation was found
-  def self.human_attribute_name(attribute, *args)
+  def human_attribute_name(attribute, *args)
     s_(gettext_translation_for_attribute_name(attribute))
   end
 
   # CarDealer -> _('car dealer')
-  def self.human_name(*args)
+  def human_name(*args)
     _(self.human_name_without_translation)
   end
 
-  def self.human_name_without_translation
+  def human_name_without_translation
     self.to_s.underscore.gsub('_',' ')
   end
 
   private
 
-  def self.gettext_translation_for_attribute_name(attribute)
+  def gettext_translation_for_attribute_name(attribute)
     "#{self}|#{attribute.to_s.split('.').map! {|a| a.gsub('_',' ').capitalize }.join('|')}"
   end
 end

--- a/lib/gettext_i18n_rails/railtie.rb
+++ b/lib/gettext_i18n_rails/railtie.rb
@@ -2,8 +2,17 @@
 if defined?(Rails::Railtie)
   module GettextI18nRails
     class Railtie < ::Rails::Railtie
+      config.gettext_i18n_rails = ActiveSupport::OrderedOptions.new
+      config.gettext_i18n_rails.use_for_active_record_attributes = true
       rake_tasks do
         require 'gettext_i18n_rails/tasks'
+      end
+      initializer 'gettext_i18n_rails.active_record_attibutes' do |app|
+        if app.config.gettext_i18n_rails.use_for_active_record_attributes
+          ActiveSupport.on_load :active_record do
+            extend GettextI18nRails::ActiveRecord
+          end
+        end
       end
     end
   end

--- a/spec/gettext_i18n_rails/active_record_spec.rb
+++ b/spec/gettext_i18n_rails/active_record_spec.rb
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(:version => 1) do
   end
 end
 
+ActiveRecord::Base.extend GettextI18nRails::ActiveRecord
+
 class CarSeat < ActiveRecord::Base
   validates_presence_of :seat_color, :message=>"translate me"
   has_many :parts


### PR DESCRIPTION
I prefer not using gettext for translating these attributes for better
compatibility with plugins and whatnot.
