### PR TITLE
Changed to public method instead of private to get store_model_attributes rake task working

### DIFF
--- a/lib/gettext_i18n_rails/active_record.rb
+++ b/lib/gettext_i18n_rails/active_record.rb
@@ -13,8 +13,6 @@ module GettextI18nRails::ActiveRecord
     self.to_s.underscore.gsub('_',' ')
   end
 
-  private
-
   def gettext_translation_for_attribute_name(attribute)
     "#{self}|#{attribute.to_s.split('.').map! {|a| a.gsub('_',' ').capitalize }.join('|')}"
   end


### PR DESCRIPTION
Hi Michael,

Have been upgrading my apps gems recently and was having problems getting a custom rake task to work:

My rake task is pretty much identical to your example though:

  FastGettext.silence_errors
  require 'gettext_i18n_rails/model_attributes_finder'
  require 'gettext_i18n_rails/active_record'

  storage_file = 'locale/model_attributes.rb'
  puts "writing model translations to: #{storage_file}"

  GettextI18nRails.store_model_attributes(
      :to => storage_file,
      :ignore_columns => [/_id$/,/_ids$/,'id',/_type$/,'type','created_at','updated_at',
                          'eula','data_filename','script','crypted_password','lookup',
                          'extra_info', 'approver_permission_order'],
      :ignore_tables => [/^sitemap_/,/_versions$/,'sessions','schema_migrations']
  )

But every time I try and run the rake task I always get the following:

*\* Execute updatepo
writing model translations to: locale/model_attributes.rb
[Error] Attribute extraction failed. Removing incomplete file (locale/model_attributes.rb)
rake aborted!
private method `gettext_translation_for_attribute_name' called for #<Class:0x8959140>
.../vendor/rails/activerecord/lib/active_record/base.rb:1998:in`method_missing'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:20:in `store_model_attributes'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:19:in`each'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:19:in `store_model_attributes'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:8:in`each'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:8:in `store_model_attributes'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:6:in`open'
.../vendor/gems/gettext_i18n_rails-0.4.0/lib/gettext_i18n_rails/model_attributes_finder.rb:6:in `store_model_attributes'
...lib/tasks/i18n.rake:11

Changing it to a public method fixes the problem.

I'm using ruby 1.8.7, Rails 2.3.14, rubygems 1.8.15, rake 0.8.7 and gettext_i18n_rails-0.4.0 (am using the 0.4.0 version to avoid the rubygems bug) but the private method still exists in your trunk, so I thought I'd let you know.

Also.. Just an FYI really, but I think the will_paginate gem when initialised in environment.rb seems to override your method_missing catch on the models when calling this method. If I have will_paginate initialised it makes your rake task crash. I'll post my stack trace in an issue ticket so you can see what I'm looking at.

Much appreciate the work you do mate. All the best.

Lucas
