### PR TITLE
Use ::ActiveRecord::Base.connection call in model_attributes_finder.rb

### DIFF
--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -39,7 +39,7 @@ module GettextI18nRails
     def find(options)
       found = Hash.new([])
 
-      connection = ActiveRecord::Base.connection
+      connection = ::ActiveRecord::Base.connection
       connection.tables.each do |table_name|
         next if ignored?(table_name,options[:ignore_tables])
         connection.columns(table_name).each do |column|


### PR DESCRIPTION
This patch fixes "uninitialized constant GettextI18nRails::ActiveRecord::Base" error
displayed when executing "rake gettext:store_model_attributes" command.
