### PR TITLE
RAILS_ROOT is deprecated

### DIFF
--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -113,7 +113,7 @@ namespace :gettext do
   def locale_path
     FastGettext.translation_repositories[text_domain].instance_variable_get(:@options)[:path]
   rescue
-    File.join(RAILS_ROOT, "locale")
+    File.join(Rails.root, "locale")
   end
 
   def text_domain


### PR DESCRIPTION
RAILS_ROOT is no longer present in Rails 3.2
