### PR TITLE
fixes loading of active model patch when in Rails app

### DIFF
--- a/lib/gettext_i18n_rails/railtie.rb
+++ b/lib/gettext_i18n_rails/railtie.rb
@@ -14,9 +14,6 @@ if defined?(Rails::Railtie)
         if app.config.gettext_i18n_rails.use_for_active_record_attributes
           ActiveSupport.on_load :active_record do
             extend GettextI18nRails::ActiveRecord
-          end
-
-          ActiveSupport.on_load :active_model do
             require 'gettext_i18n_rails/active_model.rb'
           end
         end


### PR DESCRIPTION
My previous patch had a bug where the ActiveModel monkey patch wasn't being loaded when in a Rails app. Unfortunately, this is untestable without including a lot more of Rails into the unit tests.
