### PR TITLE
fixes rake task broken by rename

### DIFF
--- a/lib/gettext_i18n_rails/active_model.rb
+++ b/lib/gettext_i18n_rails/active_model.rb
@@ -1,7 +1,7 @@
 module ActiveModel
   class Name < String
     def human(options={})
-      _(@klass.humanize_class_name(self))
+      _(@klass.humanize_class_name)
     end
   end
 end

--- a/lib/gettext_i18n_rails/active_record.rb
+++ b/lib/gettext_i18n_rails/active_record.rb
@@ -4,13 +4,13 @@ module GettextI18nRails::ActiveRecord
     s_(gettext_translation_for_attribute_name(attribute))
   end
 
-  # CarDealer -> _('car dealer')
   # method deprecated in Rails 3.1
   def human_name(*args)
-    _(self.humanize_class_name(self.to_s))
+    _(self.humanize_class_name)
   end
 
-  def humanize_class_name(name)
+  def humanize_class_name(name=nil)
+    name ||= self.to_s
     name.underscore.humanize
   end
 

--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -9,7 +9,7 @@ module GettextI18nRails
       File.open(file,'w') do |f|
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
         ModelAttributesFinder.new.find(options).each do |model,column_names|
-          f.puts("_('#{model.human_name_without_translation}')")
+          f.puts("_('#{model.humanize_class_name}')")
 
           #all columns namespaced under the model
           column_names.each do |attribute|


### PR DESCRIPTION
I found a bug that I introduced in the store_model_attributes rake task. Once again the bug is difficult to test because it is in the code only invoked by the rake task.

I apologize :(
