### PR TITLE
Show offending files' paths when it's impossible to parse them

### DIFF
--- a/lib/gettext_i18n_rails/base_parser.rb
+++ b/lib/gettext_i18n_rails/base_parser.rb
@@ -16,7 +16,7 @@ module GettextI18nRails
       code = convert_to_code(File.read(file))
       RubyGettextExtractor.parse_string(code, file, msgids)
     rescue Racc::ParseError => e
-      $stderr.puts "file ignored: ruby_parser cannot read #{extension} files with 1.9 syntax --- (#{e.message})"
+      $stderr.puts "file ignored: ruby_parser cannot read #{extension} files with 1.9 syntax --- #{file}: (#{e.message.strip})"
       return msgids
     end
 

--- a/spec/gettext_i18n_rails/haml_parser_spec.rb
+++ b/spec/gettext_i18n_rails/haml_parser_spec.rb
@@ -23,9 +23,9 @@ describe GettextI18nRails::HamlParser do
       end
     end
 
-    it "ignores 1.9 errors" do
+    it "ignores 1.9 errors and shows the paths of offending files" do
       with_file '= _("xxxx", x: 1)' do |path|
-        $stderr.should_receive(:puts).with{|x| x =~ /file ignored/ }
+        $stderr.should_receive(:puts).with{|x| x =~ /file ignored.*#{path}/ }
         parser.parse(path, [1]).should == [1]
       end
     end


### PR DESCRIPTION
It was hard for me to determine which files annoyed the ruby_parser, so I added the path name to gettext_i18n_rails output.

Includes test/spec :)
