### PR TITLE
I just created the gettext_i18n_rails_js extension, may be worth mentioning it in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -203,6 +203,11 @@ lib/tasks/gettext.rake:
       end
     end
 
+Using your translations from javascript
+=======================================
+
+If want to use your .PO files on client side javascript you should have a look at the [GettextI18nRailsJs](https://github.com/nubis/gettext_i18n_rails_js) extension.
+
 [Contributors](http://github.com/grosser/gettext_i18n_rails/contributors)
 ======
  - [ruby gettext extractor](http://github.com/retoo/ruby_gettext_extractor/tree/master) from [retoo](http://github.com/retoo)


### PR DESCRIPTION
I just created https://github.com/nubis/gettext_i18n_rails_js. It includes the js and coffee parser, and registers it as a gettext parser. As the parser is required at the toplevel in the provided tasks, there is no need to require it again explicitly in the gettext_i18n_rails code. You're upstream for me now, so I'll make sure nothing breaks on my end if you update any of the rake tasks.

I just changed the readme here to point people to the other project if they need client side translations. If you believe such links don't belong in the readme file let me know and I'll close the pull request.

cheers!
