### PR TITLE
Only interpolate strings when asked to

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -56,7 +56,8 @@ module GettextI18nRails
           I18n::Backend::Base::RESERVED_KEYS
         end
 
-        string % values.except(*reserved_keys)
+        options = values.except(*reserved_keys)
+        options.any? ? (string % options) : string
       else
         string
       end

--- a/spec/gettext_i18n_rails/backend_spec.rb
+++ b/spec/gettext_i18n_rails/backend_spec.rb
@@ -32,6 +32,13 @@ describe GettextI18nRails::Backend do
       subject.translate('xx','c',:scope=>['ab'], :a => 'X').should == 'aXb'
     end
 
+    it "will not try and interpolate when there are no options given" do
+      result = 'aXb'
+      result.should_receive(:%).never
+      FastGettext.stub(:current_repository).and_return 'ab.c' => result
+      subject.translate('xx','c', :scope=>['ab']).should == 'aXb'
+    end
+
     it "can translate with gettext using symbols" do
       FastGettext.stub(:current_repository).and_return 'xy.z.v'=>'a'
       subject.translate('xx',:v ,:scope=>['xy','z']).should == 'a'


### PR DESCRIPTION
OK, let me see if I can explain this clearly :)

We ran into a problem due to the fact that when GettextRailsI18n::Backend translates a string, it _always_ interpolates it by passing a hash to the `%` method of the translated string. We think that this isn't always the desired behavior, and this patch will only cause interpolation to happen when the caller intends it to happen by supplying an options hash.

Sometimes, as in the case of Paperclip's `number.human.storage_units.format` string , the translated string is a format to be used for other purposes. This format (along with date and time formats) contains something like `%n %u`. However, since this I18n backend would always call `%` on the translated string, we'd get expectations due to the facts that `%n %u` is not a valid interpolation format, though this case is valid for localization purposes.

Another case that would generate an error is if the translated string contains a date/time format such as `%Y-%m-%d %H:%M%S`.

Thanks!
