### PR TITLE
Fix extracting concatenated strings with ruby_parser >= 3

### DIFF
--- a/lib/gettext_i18n_rails/ruby_gettext_extractor.rb
+++ b/lib/gettext_i18n_rails/ruby_gettext_extractor.rb
@@ -59,23 +59,14 @@ module RubyGettextExtractor
       elsif node.first == :call
         type, recv, meth, args = node
 
-        # node has to be in form of "string"+("other_string")
+        # node has to be in form of "string"+"other_string"
         return nil unless recv && meth == :+
 
-        # descent recurrsivly to determine the 'receiver' of the string concatination
-        # "foo" + "bar" + baz" is
-        # ("foo".+("bar")).+("baz")
         first_part = extract_string(recv)
+        second_part = extract_string(args)
 
-        if args.first == :arglist && args.size == 2
-          second_part = extract_string(args.last)
-
-          return nil if second_part.nil?
-
-          return first_part.to_s + second_part.to_s
-        else
-          raise "uuh?"
-        end
+        return nil unless first_part && second_part
+        return first_part.to_s + second_part.to_s
       else
         return nil
       end

--- a/spec/gettext_i18n_rails/haml_parser_spec.rb
+++ b/spec/gettext_i18n_rails/haml_parser_spec.rb
@@ -23,6 +23,14 @@ describe GettextI18nRails::HamlParser do
       end
     end
 
+    it "finds messages with concatenation" do
+      with_file '= _("xxxx" + "yyyy" + "zzzz")' do |path|
+        parser.parse(path, []).should == [
+          ["xxxxyyyyzzzz", "#{path}:1"]
+        ]
+      end
+    end
+
     it "should parse the 1.9 if ruby_version is 1.9" do
       if RUBY_VERSION =~ /^1\.9/
         with_file '= _("xxxx", x: 1)' do |path|


### PR DESCRIPTION
The AST of "one" + "two" + "three" looks differently (no nesting) with
ruby_parser >= 3. Update extractor to accommodate this change.

Fixing #86 and #87
