### PR TITLE
Dropped haml 1.9 hashes warning in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,8 +28,7 @@ Setup
 
 ##### Optional:
 Add `gettext` if you want to find translations or build .mo files<br/>
-Add `ruby_parser` if you want to find translations inside haml/slim files (does not support ruby 1.9 syntax)
-
+Add `ruby_parser` if you want to find translations inside haml/slim files
 
     # Gemfile
     gem 'gettext', '>=1.9.3', :require => false, :group => :development


### PR DESCRIPTION
Dropped warning about not supporting 1.9 hashes in haml. Check
https://github.com/seattlerb/ruby_parser/issues/37
