### PR TITLE
Handle count option

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -17,7 +17,11 @@ module GettextI18nRails
 
     def translate(locale, key, options)
       if gettext_key = gettext_key(key, options)
-        translation = FastGettext._(gettext_key)
+        translation = if options[:count]
+                        FastGettext.n_(gettext_key, options[:count])
+                      else
+                        FastGettext._(gettext_key)
+                      end
         interpolate(translation, options)
       else
         result = backend.translate(locale, key, options)

--- a/spec/gettext_i18n_rails/backend_spec.rb
+++ b/spec/gettext_i18n_rails/backend_spec.rb
@@ -41,6 +41,15 @@ describe GettextI18nRails::Backend do
       subject.translate('xx', 'd', :scope=>['ab']).should == 'a%{a}b'
     end
 
+    it "uses plural translation if count is given" do
+      repo = {'ab.e' => 'existing'}
+      repo.should_receive(:plural).and_return %w(single plural)
+      repo.stub(:pluralisation_rule).and_return nil
+      FastGettext.stub(:current_repository).and_return repo
+      subject.translate('xx', 'ab.e', :count => 1).should == 'single'
+      subject.translate('xx', 'ab.e', :count => 2).should == 'plural'
+    end
+
     it "can translate with gettext using symbols" do
       FastGettext.should_receive(:current_repository).and_return 'xy.z.v'=>'a'
       subject.translate('xx',:v ,:scope=>['xy','z']).should == 'a'


### PR DESCRIPTION
I want to use gettext_i18n_rails with db repository to completely replace I18n.

But when it comes to some rails helper methods such as time_ago_in_words, things do not work as expected.

Behind the scene, rails uses something like I18n.t("datetime.distance_in_words.about_x_hours", :count => 1) to translate the time. However, gettext_i18n_rails does not handle count option, which make the translation impossible

The idea is to call the plural translation when the count option is given.
