### PR TITLE
Fix regression with direct count interpolations

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -17,11 +17,8 @@ module GettextI18nRails
 
     def translate(locale, key, options)
       if gettext_key = gettext_key(key, options)
-        translation = if options[:count]
-                        FastGettext.n_(gettext_key, options[:count])
-                      else
-                        FastGettext._(gettext_key)
-                      end
+        translation =
+          plural_translate(gettext_key, options) || FastGettext._(gettext_key)
         interpolate(translation, options)
       else
         result = backend.translate(locale, key, options)
@@ -49,6 +46,21 @@ module GettextI18nRails
           return default if FastGettext.key_exist?(default)
         end
         return nil
+      end
+    end
+
+    def plural_translate(gettext_key, options)
+      if options[:count]
+        translation = FastGettext.n_(gettext_key, options[:count])
+        discard_pass_through_key gettext_key, translation
+      end
+    end
+
+    def discard_pass_through_key(key, translation)
+      if translation == key
+        nil
+      else
+        translation
       end
     end
 

--- a/spec/gettext_i18n_rails/backend_spec.rb
+++ b/spec/gettext_i18n_rails/backend_spec.rb
@@ -50,6 +50,14 @@ describe GettextI18nRails::Backend do
       subject.translate('xx', 'ab.e', :count => 2).should == 'plural'
     end
 
+    it "interpolates a count without plural translations" do
+      repo = {'ab.e' => 'existing %{count}'}
+      repo.should_receive(:plural).and_return []
+      repo.stub(:pluralisation_rule).and_return lambda { |i| true }
+      FastGettext.stub(:current_repository).and_return repo
+      subject.translate('xx', 'ab.e', :count => 1).should == 'existing 1'
+    end
+
     it "can translate with gettext using symbols" do
       FastGettext.should_receive(:current_repository).and_return 'xy.z.v'=>'a'
       subject.translate('xx',:v ,:scope=>['xy','z']).should == 'a'


### PR DESCRIPTION
- Rails uses translations like "must be greater than %{count}"
- These translations accept a count but don't pluralize
- Commit 1f4bb188 (#95) introduced a regression
- These unpluralized translations would return the original key
