### PR TITLE
rake tasks - added support for gettext-3.0

### DIFF
--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -3,10 +3,11 @@ namespace :gettext do
     require 'gettext'
 
     begin
-      require 'gettext/utils'
-    rescue LoadError
       # gettext 3.0
       require 'gettext/tools'
+    rescue LoadError
+      # gettext <= 2.3.9
+      require 'gettext/utils'
     end
   end
 


### PR DESCRIPTION
see https://github.com/ruby-gettext/gettext/blob/master/doc/text/news.md#300-2013-08-31
for gettext-3.0.0 changes
