### PR TITLE
Use GetText::Tools::Task introduced since gettext 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'appraisal'
 gem 'bump'
-gem 'gettext'
+gem 'gettext', '>= 3.0.1'
 gem 'haml'
 gem 'rails'
 gem 'rake'

--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -1,55 +1,47 @@
+require "gettext/tools/task"
+
 namespace :gettext do
-  def load_gettext
-    require 'gettext'
-    require 'gettext/utils'
+  def locale_path
+    path = FastGettext.translation_repositories[text_domain].instance_variable_get(:@options)[:path] rescue nil
+    path || File.join(Rails.root, "locale")
+  end
+
+  def text_domain
+    # if your textdomain is not 'app': require the environment before calling e.g. gettext:find OR add TEXTDOMAIN=my_domain
+    ENV['TEXTDOMAIN'] || (FastGettext.text_domain rescue nil) || "app"
+  end
+
+  # do not rename, gettext_i18n_rails_js overwrites this to inject coffee + js
+  def files_to_translate
+    Dir.glob("{app,lib,config,#{locale_path}}/**/*.{rb,erb,haml,slim}")
+  end
+
+  $LOAD_PATH << File.join(File.dirname(__FILE__),'..','..','lib') # needed when installed as plugin
+
+  require "gettext_i18n_rails/haml_parser"
+  require "gettext_i18n_rails/slim_parser"
+
+  GetText::Tools::Task.define do |task|
+    task.package_name = text_domain
+    task.package_version = "1.0.0"
+    task.domain = text_domain
+    task.po_base_directory = locale_path
+    task.mo_base_directory = locale_path
+    task.files = files_to_translate
+    task.enable_description = false
+    if defined?(Rails.application)
+      msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
+    end
+    msgmerge ||= %w[--sort-output --no-location --no-wrap]
+    task.msgmerge_options = msgmerge
   end
 
   desc "Create mo-files for L10n"
-  task :pack => :environment do
-    load_gettext
-    GetText.create_mofiles(true, locale_path, locale_path)
+  task :pack => [:environment, "gettext:gettext:mo:update"] do
   end
 
   desc "Update pot/po files."
-  task :find => :environment do
-    load_gettext
-    $LOAD_PATH << File.join(File.dirname(__FILE__),'..','..','lib') # needed when installed as plugin
-
-    require "gettext_i18n_rails/haml_parser"
-    require "gettext_i18n_rails/slim_parser"
-
-    if GetText.respond_to? :update_pofiles_org
-      if defined?(Rails.application)
-        msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
-      end
-      msgmerge ||= %w[--sort-output --no-location --no-wrap]
-
-      GetText.update_pofiles_org(
-        text_domain,
-        files_to_translate,
-        "version 0.0.1",
-        :po_root => locale_path,
-        :msgmerge => msgmerge
-      )
-    else #we are on a version < 2.0
-      puts "install new GetText with gettext:install to gain more features..."
-      #kill ar parser...
-      require 'gettext/parser/active_record'
-      module GetText
-        module ActiveRecordParser
-          module_function
-          def init(x);end
-        end
-      end
-
-      #parse files.. (models are simply parsed as ruby files)
-      GetText.update_pofiles(
-        text_domain,
-        files_to_translate,
-        "version 0.0.1",
-        locale_path
-      )
-    end
+  task :find => [:environment, "gettext:gettext:po:update"] do
   end
 
   # This is more of an example, ignoring
@@ -92,35 +84,9 @@ namespace :gettext do
       puts "You need to specify the language to add. Either 'LANGUAGE=eo rake gettext:add_languange' or 'rake gettext:add_languange[eo]'"
       next
     end
-    pot = File.join(locale_path, "#{text_domain}.pot")
-    if !File.exists? pot
-      puts "You don't have a pot file yet, you probably should run 'rake gettext:find' at least once. Tried '#{pot}'."
-      next
-    end
 
-    # Create the directory for the new language.
-    dir = File.join(locale_path, language)
-    puts "Creating directory #{dir}"
-    Dir.mkdir dir
-
-    # Create the po file for the new language.
-    new_po = File.join(locale_path, language, "#{text_domain}.po")
-    puts "Initializing #{new_po} from #{pot}."
-    system "msginit --locale=#{language} --input=#{pot} --output=#{new_po}"
-  end
-
-  def locale_path
-    path = FastGettext.translation_repositories[text_domain].instance_variable_get(:@options)[:path] rescue nil
-    path || File.join(Rails.root, "locale")
-  end
-
-  def text_domain
-    # if your textdomain is not 'app': require the environment before calling e.g. gettext:find OR add TEXTDOMAIN=my_domain
-    ENV['TEXTDOMAIN'] || (FastGettext.text_domain rescue nil) || "app"
-  end
-
-  # do not rename, gettext_i18n_rails_js overwrites this to inject coffee + js
-  def files_to_translate
-    Dir.glob("{app,lib,config,#{locale_path}}/**/*.{rb,erb,haml,slim}")
+    language_path = File.join(locale_path, language)
+    mkdir_p(language_path)
+    ruby($0, "gettext:find")
   end
 end


### PR DESCRIPTION
This commit is for #101.

This commit requires gettext 3.0.1 (it is not released yet) or
later. Older gettext doesn't support. (Is it OK?)

This commit also disables lazy gettext gem require. Because we don't
use GetText::Tools::Task after requiring gettext gem. (Is it OK?)

We can add shim code to support both gettext 3.0.1 or later and old
versions. We try to require `gettext/tools/task`. If we succeed it, we
assume that we have gettext 3.0.1 or later. We use this commit's
code. If we fail it, we assume that we have old gettext. We use the
previous code.

@grosser, what do you think about this approach?
If you are OK for this approach. I will release gettext 3.0.1.
If you are not OK, I can retry a pull request that reflects your suggestion. :-)
