### PR TITLE
Reload po files when modified

### DIFF
--- a/lib/gettext_i18n_rails/railtie.rb
+++ b/lib/gettext_i18n_rails/railtie.rb
@@ -21,14 +21,12 @@ module GettextI18nRails
         end
       end
       repo = FastGettext.translation_repositories[FastGettext.text_domain]
-      if repo.is_a? FastGettext::TranslationRepository::Po
-        reloader = ActiveSupport::FileUpdateChecker.new([], FastGettext.locale_path => :po) do
-          FastGettext.reload!
-        end
-        app.reloaders << reloader
-        ActionDispatch::Reloader.to_prepare do
-          reloader.execute
-        end
+      reloader = ActiveSupport::FileUpdateChecker.new([], FastGettext.locale_path => :po) do
+        FastGettext.reload!
+      end
+      app.reloaders << reloader
+      ActionDispatch::Reloader.to_prepare do
+        reloader.execute
       end
     end
   end


### PR DESCRIPTION
We're hooking into Rails autoload mechanism like the I18n railtie does when using po files. This means you can edit the po file, and test the new translation in your browser without having to restart rails.

It's probably possible to get this working with mo files aswell, but simply adding the mo extension to monitor didn't seem to do the trick, so for now, we're just handling po files.
