### PR TITLE
seems we now need to run gettext:pot:create to update the pot file

### DIFF
--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -58,6 +58,7 @@ namespace :gettext do
 
   desc "Update pot/po files"
   task :find => [:setup] do
+    Rake::Task["gettext:pot:create"].invoke
     Rake::Task["gettext:po:update"].invoke
   end
 


### PR DESCRIPTION
I've pulled in latest gettext from https://github.com/ruby-gettext/gettext to avoid fuzzy matching when updating po files and noticed that my pot file was no longer updated when running `rake gettext:find`. I couldn't pin this to any specific commit in gettext, but running gettext:pot:create upfront works fine for me. 
