### PR TITLE
ManageIQ fixes

### DIFF
--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -41,6 +41,10 @@ module GettextI18nRails
       found
     end
 
+    def initialize
+      @existing_tables = ActiveRecord::Base.connection.tables
+    end
+
     # Rails < 3.0 doesn't have DescendantsTracker. 
     # Instead of iterating over ObjectSpace (slow) the decision was made NOT to support
     # class hierarchies with abstract base classes in Rails 2.x
@@ -51,7 +55,7 @@ module GettextI18nRails
         model.direct_descendants.reject {|m| ignored?(m.table_name, ignored_tables)}.inject([]) do |attrs, m|
           attrs.push(model_attributes(m, ignored_tables, ignored_cols)).flatten.uniq
         end
-      elsif !ignored?(model.table_name, ignored_tables)
+      elsif !ignored?(model.table_name, ignored_tables) && @existing_tables.include?(model.table_name)
         model.columns.reject { |c| ignored?(c.name, ignored_cols) }.collect { |c| c.name }
       else
         []

--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -79,7 +79,7 @@ namespace :gettext do
     require 'gettext_i18n_rails/model_attributes_finder'
     require 'gettext_i18n_rails/active_record'
 
-    storage_file = "#{locale_path}/model_attributes.rb"
+    storage_file = "#{locale_path}/../model_attributes.rb"
     puts "writing model translations to: #{storage_file}"
 
     ignore_tables = [/^sitemap_/, /_versions$/, 'schema_migrations', 'sessions', 'delayed_jobs']


### PR DESCRIPTION
Hi. 

I am opening this to discuss 2 issues (and ways to fix them) that I have hit while trying to add gettext_i18n_rails to our project.

First problem is that we have models w/o tables and when running `gettext:store_model_attributes` we get:
```
$ rake gettext:store_model_attributes

writing model translations
to: /home/jzigmund/manageiq/vmdb/config/locales/model_attributes.rb
[Error] Attribute extraction failed. Removing incomplete file
(/home/jzigmund/manageiq/vmdb/config/locales/model_attributes.rb)
rake aborted!

ActiveRecord::StatementInvalid: PGError: ERROR: relation
"miq_region_remotes" does not exist
LINE 5: WHERE a.attrelid = '"miq_region_remotes"'::regc...
^
: SELECT a.attname, format_type(a.atttypid, a.atttypmod),
pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
FROM pg_attribute a LEFT JOIN pg_attrdef d
ON a.attrelid = d.adrelid AND a.attnum = d.adnum
WHERE a.attrelid = '"miq_region_remotes"'::regclass
AND a.attnum > 0 AND NOT a.attisdropped
ORDER BY a.attnum

Tasks: TOP => gettext:store_model_attributes
```

The 2nd problem is that when the `gettext:store_model_attributes` writes to `application_base/config/locales/model_attributes.rb` and at the same time it loads one model after another, then the file being generated get's loaded by I18n. And I18n expects the file to evaluate into `hash` it seems:
```
=> #<I18n::InvalidLocaleData: can not load translations from /home/martin/Projects/manageiq/vmdb/config/locales/model_attributes.rb: expects it to return a hash, but does not:
```
[2] pry(GettextI18nRails)> e.backtrace
=> ["/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:168:in `load_file'",
=> ["/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:168:in `load_file'",
=> ["/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:168:in `load_file'",
 "/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:15:in `block in load_translations'",
 "/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:15:in `each'",
 "/home/martin/.rvm/gems/ruby-1.9.3-p392@cfme/gems/i18n-0.6.11/lib/i18n/backend/base.rb:15:in `load_translations'",
```

By moving the generated file one level up I prevent I18n from loading it.

I'd like to hear any feedback on whether the approach in this PR is acceptable or if I shall address the issues in any other way.

Thanks and regards!