### PR TITLE
Inherit scope

### DIFF
--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -101,9 +101,6 @@ namespace :gettext do
 
     language_path = File.join(locale_path, language)
     mkdir_p(language_path)
-    b = false
-    scope = _.scope.reject{|x| b || x == 'gettext' ? b = true : false}.join(':')
-    scope += ':' unless scope.empty?
-    ruby($0, "#{scope}gettext:find")
+    Rake.application.lookup('gettext:find', _.scope).invoke
   end
 end

--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -101,6 +101,9 @@ namespace :gettext do
 
     language_path = File.join(locale_path, language)
     mkdir_p(language_path)
-    ruby($0, "gettext:find")
+    b = false
+    scope = _.scope.reject{|x| b || x == 'gettext' ? b = true : false}.join(':')
+    scope += ':' unless scope.empty?
+    ruby($0, "#{scope}gettext:find")
   end
 end


### PR DESCRIPTION
"rake gettext:find" here fails when the task has another scope.
that should be inherited to accomplish the task.