### PR TITLE
Unify parse signature with gettext

### DIFF
--- a/lib/gettext_i18n_rails/base_parser.rb
+++ b/lib/gettext_i18n_rails/base_parser.rb
@@ -6,7 +6,7 @@ module GettextI18nRails
       File.extname(file) == ".#{extension}"
     end
 
-    def self.parse(file, msgids = [])
+    def self.parse(file, _options = {}, msgids = [])
       return msgids unless load_library
       code = convert_to_code(File.read(file))
       RubyGettextExtractor.parse_string(code, msgids, file)

--- a/spec/gettext_i18n_rails/haml_parser_spec.rb
+++ b/spec/gettext_i18n_rails/haml_parser_spec.rb
@@ -17,7 +17,7 @@ describe GettextI18nRails::HamlParser do
   describe "#parse" do
     it "finds messages in haml" do
       with_file '= _("xxxx")' do |path|
-        parser.parse(path, []).should == [
+        parser.parse(path, {}, []).should == [
           ["xxxx", "#{path}:1"]
         ]
       end
@@ -25,7 +25,7 @@ describe GettextI18nRails::HamlParser do
 
     it "finds messages with concatenation" do
       with_file '= _("xxxx" + "yyyy" + "zzzz")' do |path|
-        parser.parse(path, []).should == [
+        parser.parse(path, {}, []).should == [
           ["xxxxyyyyzzzz", "#{path}:1"]
         ]
       end
@@ -34,7 +34,7 @@ describe GettextI18nRails::HamlParser do
     it "should parse the 1.9 if ruby_version is 1.9" do
       if RUBY_VERSION =~ /^1\.9/
         with_file '= _("xxxx", x: 1)' do |path|
-          parser.parse(path, []).should == [
+          parser.parse(path, {}, []).should == [
             ["xxxx", "#{path}:1"]
           ]
         end
@@ -43,7 +43,7 @@ describe GettextI18nRails::HamlParser do
 
     it "does not find messages in text" do
       with_file '_("xxxx")' do |path|
-        parser.parse(path, []).should == []
+        parser.parse(path, {}, []).should == []
       end
     end
   end

--- a/spec/gettext_i18n_rails/haml_parser_spec.rb
+++ b/spec/gettext_i18n_rails/haml_parser_spec.rb
@@ -46,5 +46,11 @@ describe GettextI18nRails::HamlParser do
         parser.parse(path, {}, []).should == []
       end
     end
+
+    it "does not include parser options into parsed output" do
+      with_file '= _("xxxx")' do |path|
+        parser.parse(path, {:option => "value"}).should_not include([:option, "value"])
+      end
+    end
   end
 end

--- a/spec/gettext_i18n_rails/slim_parser_spec.rb
+++ b/spec/gettext_i18n_rails/slim_parser_spec.rb
@@ -17,7 +17,7 @@ describe GettextI18nRails::SlimParser do
   describe "#parse" do
     it "finds messages in slim" do
       with_file 'div = _("xxxx")' do |path|
-        parser.parse(path, []).should == [
+        parser.parse(path, {}, []).should == [
           ["xxxx", "#{path}:1"]
         ]
       end
@@ -25,7 +25,7 @@ describe GettextI18nRails::SlimParser do
 
     xit "can parse 1.9 syntax" do
       with_file 'div = _("xxxx", foo: :bar)' do |path|
-        parser.parse(path, []).should == [
+        parser.parse(path, {}, []).should == [
           ["xxxx", "#{path}:1"]
         ]
       end
@@ -33,7 +33,7 @@ describe GettextI18nRails::SlimParser do
 
     it "does not find messages in text" do
       with_file 'div _("xxxx")' do |path|
-        parser.parse(path, []).should == []
+        parser.parse(path, {}, []).should == []
       end
     end
   end


### PR DESCRIPTION
in `gettext/tools/xgettext.rb`
in `def parse_path(path, po)`

there's:
```
 if parser.method(:parse).arity == 1 or @parse_options.empty?
   extracted_po = parser.parse(path)
 else
   extracted_po = parser.parse(path, @parse_options)
 end
```
once we have some `@parse_options`, such as:

```
[1] pry(#<GetText::Tools::XGetText>)> @parse_options
=> {:comment_tag=>"TRANSLATORS"}
```

and because `gettext_i18n_rails parser` has `arity` != 1 so 
        `parser.parse(path, @parse_options)` get's called

in gettext_i18n_rails we have the signature: `def parse_string(content, targets = [], file = nil)`

and we get a crash later on:

```
devil - [~/Projects/manageiq-2] (master)$ rm config/locales/manageiq.pot ; bundle exec rake gettext:find
#<GetText::RubyLexX:0x000000061937b8>#<GetText::RubyLexX:0x000000061937b8>Error parsing app/views/shared/buttons/_group_order_form.html.haml
rake aborted!
NoMethodError: undefined method `include?' for :comment_tag:Symbol
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:421:in `create_po_entry'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:372:in `block (2 levels) in parse_path'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:370:in `each'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:370:in `block in parse_path'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:360:in `each'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:360:in `parse_path'
/home/martin/.rvm/gems/ruby-2.2.2@cfme/gems/gettext-3.1.4/lib/gettext/tools/xgettext.rb:168:in `block in parse'
```                                                                                                               

This patch fixes this issue on our way to have translator hints for our app (https://github.com/ManageIQ/manageiq/pull/4889)

