### PR TITLE
Fix ActiveRecord namespacing for store_model_attributes

### DIFF
--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -42,7 +42,7 @@ module GettextI18nRails
     end
 
     def initialize
-      @existing_tables = ActiveRecord::Base.connection.tables
+      @existing_tables = ::ActiveRecord::Base.connection.tables
     end
 
     # Rails < 3.0 doesn't have DescendantsTracker. 


### PR DESCRIPTION
Similar to ff86ab7ed60dc36875ad7de2688710eeefdddfe7, this fixes a "uninitialized constant GettextI18nRails::ActiveRecord::Base when running the store_model_attributes task