### PR TITLE
Allow passing options to msgcat

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -243,6 +243,7 @@ namespace :gettext do
         task.files = files
         task.enable_description = false
         task.msgmerge_options = gettext_msgmerge_options
+        task.msgcat_options = gettext_msgcat_options
         task.xgettext_options = gettext_xgettext_options
       end
     end
@@ -250,8 +251,8 @@ namespace :gettext do
 end
 ```
 
-Changing msgmerge and xgettext options
-======================================
+Changing msgmerge, msgcat, and xgettext options
+===============================================
 
 The default options for parsing and create `.po` files are:
 
@@ -265,6 +266,7 @@ If you want to override them you can put the following into an initializer like 
 
 ```Ruby
 Rails.application.config.gettext_i18n_rails.msgmerge = %w[--no-location]
+Rails.application.config.gettext_i18n_rails.msgcat = %w[--no-location]
 Rails.application.config.gettext_i18n_rails.xgettext = %w[--no-location]
 ```
 
@@ -276,7 +278,7 @@ Rails.application.config.gettext_i18n_rails.default_options = %w[--no-location]
 
 to override both.
 
-You can see the available options by running `rgettext -h` and `rxgettext -h`.
+You can see the available options by running `rgettext -h`, `rmsgcat -f` and `rxgettext -h`.
 
 Using your translations from javascript
 =======================================

--- a/lib/gettext_i18n_rails/railtie.rb
+++ b/lib/gettext_i18n_rails/railtie.rb
@@ -2,6 +2,7 @@ module GettextI18nRails
   class Railtie < ::Rails::Railtie
     config.gettext_i18n_rails = ActiveSupport::OrderedOptions.new
     config.gettext_i18n_rails.msgmerge = nil
+    config.gettext_i18n_rails.msgcat = nil
     config.gettext_i18n_rails.xgettext = nil
     config.gettext_i18n_rails.use_for_active_record_attributes = true
 

--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -27,6 +27,11 @@ namespace :gettext do
     config || gettext_default_options
   end
 
+  def gettext_msgcat_options
+    config = (Rails.application.config.gettext_i18n_rails.msgcat if defined?(Rails.application))
+    config || gettext_default_options
+  end
+
   def gettext_xgettext_options
     config = (Rails.application.config.gettext_i18n_rails.xgettext if defined?(Rails.application))
     config || gettext_default_options
@@ -45,6 +50,7 @@ namespace :gettext do
       task.files = files_to_translate
       task.enable_description = false
       task.msgmerge_options = gettext_msgmerge_options
+      task.msgcat_options = gettext_msgcat_options
       task.xgettext_options = gettext_xgettext_options
     end
   end


### PR DESCRIPTION
Without this msgcat doesn't get the --no-wrap option and so wraps long translations when merging files.