### PR TITLE
Filter out options unknown to msgcat

### DIFF
--- a/lib/gettext_i18n_rails/tasks.rb
+++ b/lib/gettext_i18n_rails/tasks.rb
@@ -29,7 +29,7 @@ namespace :gettext do
 
   def gettext_msgcat_options
     config = (Rails.application.config.gettext_i18n_rails.msgcat if defined?(Rails.application))
-    config || gettext_default_options
+    config || gettext_default_options - %w[--location]
   end
 
   def gettext_xgettext_options


### PR DESCRIPTION
msgcat does not have the --location option. When passed this option
msgcat will abort with an error, causing e.g. the gettext:find task to
be incomplete.

Fixes #152