### PR TITLE
Fix Rails 5 compatibility.

### DIFF
--- a/spec/gettext_i18n_rails/model_attributes_finder_spec.rb
+++ b/spec/gettext_i18n_rails/model_attributes_finder_spec.rb
@@ -25,6 +25,7 @@ describe GettextI18nRails::ModelAttributesFinder do
       expected = [CarSeat, Part, StiParent]
       expected.concat [AbstractParentClass, NotConventional] if Rails::VERSION::MAJOR >= 3
       expected.concat [ActiveRecord::SchemaMigration] if Rails::VERSION::MAJOR >= 4
+      expected.concat [ActiveRecord::InternalMetadata] if Rails::VERSION::MAJOR >= 5
       keys.should =~ expected
     end
 


### PR DESCRIPTION
Running test suite agains stable RoR 5.0, I observer following error:

```
  1) GettextI18nRails::ModelAttributesFinder#find returns all AR models
     Failure/Error: keys.should =~ expected

       expected collection contained:  [CarSeat(id: integer, seat_color: string), Part(id: integer, name: string, car_seat_id: integer), Sti...stract), NotConventional(id: integer, name: string), ActiveRecord::SchemaMigration(version: string)]
       actual collection contained:    [AbstractParentClass(abstract), ActiveRecord::InternalMetadata(key: string, value: string, created_at... name: string, car_seat_id: integer), StiParent(id: integer, type: string, child_attribute: string)]
       the extra elements were:        [ActiveRecord::InternalMetadata(key: string, value: string, created_at: datetime, updated_at: datetime)]
     # ./spec/gettext_i18n_rails/model_attributes_finder_spec.rb:28:in `block (3 levels) in <top (required)>'
```

I did not investigate what is the reason for the failure, so the fix of test suite might be totally wrong solution, though.