### PR TITLE
docs: use gettext gem in all environments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ Add `ruby_parser` if you want to find translations inside haml/slim files
 
 ```Ruby
 # Gemfile
-gem 'gettext', '>=3.0.2', :require => false, :group => :development
+gem 'gettext', '>=3.0.2', :require => false
 gem 'ruby_parser', :require => false, :group => :development
 ```
 


### PR DESCRIPTION
Hi @grosser 👋🏼 

Thanks for writing this gem. My team is using it on a new project. We thought that the `gettext` gem was only needed for the `rake gettext:*` tasks, so we left the `:group => :development` statement in our Gemfile as recommended in this project's README. When we deployed to production, however, we got an [error](https://gist.github.com/zeke/36e5ec1461ff9b660253f483800f598b). It appears that `gettext_i18n_rails` does include `gettext` require statement  in [lib/gettext_i18n_rails/tasks.rb](https://github.com/zeke/gettext_i18n_rails/blob/b559cdb39292c5b81d0055dc3d0dca4903890e97/lib/gettext_i18n_rails/tasks.rb#L1)

This PR updates the README by removing the `:development` group, so that others may avoid hitting the same issue when deploying to production environments.

cc @bigzoo @mjacobus @southgate