### PR TITLE
Update Readme.md to use before_action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ And in your application:
 ```Ruby
 # app/controllers/application_controller.rb
 class ApplicationController < ...
-  before_filter :set_gettext_locale
+  before_action :set_gettext_locale
 ```
 
 Translating


### PR DESCRIPTION
`before_filter` was deprecated in Rails 5.0, so I think most people adding this to their projects would need to use `before_action`.