### PR TITLE
Bump `fast_gettext` dependency to 2.1.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gettext_i18n_rails (1.8.1)
+    gettext_i18n_rails (1.8.2)
       fast_gettext (>= 0.9.0)
 
 GEM
@@ -50,7 +50,7 @@ GEM
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    fast_gettext (2.0.1)
+    fast_gettext (2.1.0)
     gettext (3.2.2)
       locale (>= 2.0.5)
       text (>= 1.3.0)

--- a/lib/gettext_i18n_rails/version.rb
+++ b/lib/gettext_i18n_rails/version.rb
@@ -1,3 +1,3 @@
 module GettextI18nRails
-  Version = VERSION = '1.8.1'
+  Version = VERSION = '1.8.2'
 end


### PR DESCRIPTION
Version `2.1.0` of `fast_gettext` drops taint checking which is deprecated.   
`fast_gettext` is a dependency of this gem, so we update it to avoid noisy deprecation warnings in apps that would use Ruby 3.   

More details in https://github.com/grosser/fast_gettext/pull/133.