### PR TITLE
backend: translate changes the current locale

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -16,17 +16,16 @@ module GettextI18nRails
     end
 
     def translate(locale, key, options)
-      current_locale = FastGettext.set_locale locale
-      if gettext_key = gettext_key(key, options)
-        translation =
-          plural_translate(gettext_key, options) || FastGettext._(gettext_key)
-        interpolate(translation, options)
-      else
-        result = backend.translate(locale, key, options)
-        (RUBY19 and result.is_a?(String)) ? result.force_encoding("UTF-8") : result
+      I18n.with_locale(locale) do
+        if gettext_key = gettext_key(key, options)
+          translation =
+            plural_translate(gettext_key, options) || FastGettext._(gettext_key)
+          interpolate(translation, options)
+        else
+          result = backend.translate(locale, key, options)
+          (RUBY19 and result.is_a?(String)) ? result.force_encoding("UTF-8") : result
+        end
       end
-    ensure
-      FastGettext.set_locale current_locale
     end
 
     def method_missing(method, *args)

--- a/spec/gettext_i18n_rails/backend_spec.rb
+++ b/spec/gettext_i18n_rails/backend_spec.rb
@@ -57,7 +57,8 @@ describe GettextI18nRails::Backend do
       repo.should_receive(:plural).and_return []
       repo.stub(:pluralisation_rule).and_return lambda { |i| true }
       FastGettext.stub(:current_repository).and_return repo
-      FastGettext.should_receive(:set_locale).twice.with('xx').and_return('xx')
+      FastGettext.should_receive(:set_locale).with('xx').and_return('xx')
+      FastGettext.should_receive(:set_locale).with(:en).and_return(:en)
       subject.translate('xx', 'ab.e', :count => 1).should == 'existing 1'
     end
 
@@ -80,7 +81,8 @@ describe GettextI18nRails::Backend do
 
     it 'temporarily sets the given locale' do
       FastGettext.should_receive(:set_locale).with('xx').and_return('xy')
-      FastGettext.should_receive(:set_locale).twice.with('xy').and_return('xx')
+      FastGettext.should_receive(:set_locale).with('xy').and_return('xx')
+      FastGettext.should_receive(:set_locale).with(:en).and_return('xx')
       subject.backend.should_receive(:translate).with('xx', 'c', {}).and_return 'd'
       FastGettext.locale= 'xy'
       FastGettext.stub(:current_repository).and_return 'a'=>'b'
@@ -90,7 +92,8 @@ describe GettextI18nRails::Backend do
     if RUBY_VERSION > "1.9"
       it "produces UTF-8 when not using FastGettext to fix weird encoding bug" do
         subject.backend.should_receive(:translate).with('xx', 'c', {}).and_return 'ü'.force_encoding("US-ASCII")
-        FastGettext.should_receive(:set_locale).twice.with('xx').and_return('xx')
+        FastGettext.should_receive(:set_locale).with('xx').and_return('xx')
+        FastGettext.should_receive(:set_locale).with(:en).and_return(:en)
         FastGettext.should_receive(:current_repository).and_return 'a'=>'b'
         result = subject.translate('xx', 'c', {})
         result.should == 'ü'
@@ -98,7 +101,8 @@ describe GettextI18nRails::Backend do
 
       it "does not force_encoding on non-strings" do
         subject.backend.should_receive(:translate).with('xx', 'c', {}).and_return ['aa']
-        FastGettext.should_receive(:set_locale).twice.with('xx').and_return('xx')
+        FastGettext.should_receive(:set_locale).with('xx').and_return('xx')
+        FastGettext.should_receive(:set_locale).with(:en).and_return(:en)
         FastGettext.should_receive(:current_repository).and_return 'a'=>'b'
         result = subject.translate('xx', 'c', {})
         result.should == ['aa']


### PR DESCRIPTION
`FastGettext.set_locale` returns the "new" current locale, not the old one.  Use `with_locale`.

Fixes #192.