### PR TITLE
Dup frozen strings before force_encoding

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -23,7 +23,12 @@ module GettextI18nRails
           interpolate(translation, options)
         else
           result = backend.translate(locale, key, options)
-          (RUBY19 and result.is_a?(String)) ? result.force_encoding("UTF-8") : result
+          if RUBY19 && result.is_a?(String)
+           result = result.dup if result.frozen?
+           result.force_encoding("UTF-8")
+          else
+            result
+          end
         end
       end
     end

--- a/spec/gettext_i18n_rails/backend_spec.rb
+++ b/spec/gettext_i18n_rails/backend_spec.rb
@@ -79,6 +79,13 @@ describe GettextI18nRails::Backend do
       subject.translate('xx', 'c', {}).should == 'd'
     end
 
+    it "passes non-gettext keys to default backend without modifying frozen translation" do
+      subject.backend.should_receive(:translate).with('xx', 'c', {}).and_return 'd'.freeze
+      # TODO track down why this is called 3 times on 1.8 (only 1 time on 1.9)
+      FastGettext.stub(:current_repository).and_return 'a'=>'b'
+      subject.translate('xx', 'c', {}).should == 'd'
+    end
+
     it 'temporarily sets the given locale' do
       FastGettext.should_receive(:set_locale).with('xx').and_return('xy')
       FastGettext.should_receive(:set_locale).with('xy').and_return('xx')


### PR DESCRIPTION
I18n 1.13.0 changed the behavior of interpolate to retain the original object when no interpolation occurs:

https://github.com/ruby-i18n/i18n/pull/649/files

With that change, a frozen string is no longer duplicated by i18n and retains the frozen state.  This causes an error when we try to force_encoding as it's a modification in place.  This worked previously because i18n interpolate would return a new unfrozen string from a frozen string input.

```ruby
irb(main):003:0> I18n::VERSION
=> "1.13.0"
irb(main):004:0> I18n.interpolate(("get".freeze), {}).frozen?
=> true
```

vs.

```ruby
irb(main):002:0> I18n::VERSION
=> "1.12.0"
irb(main):003:0> I18n.interpolate(("get".freeze), {}).frozen?
=> false
```