### PR TITLE
Drop RUBY19. It's long been EOL

### DIFF
--- a/lib/gettext_i18n_rails/backend.rb
+++ b/lib/gettext_i18n_rails/backend.rb
@@ -5,8 +5,6 @@ module GettextI18nRails
     cattr_accessor :translate_defaults
     attr_accessor :backend
 
-    RUBY19 = (RUBY_VERSION > "1.9")
-
     def initialize(*args)
       self.backend = I18n::Backend::Simple.new(*args)
     end
@@ -23,7 +21,7 @@ module GettextI18nRails
           interpolate(translation, options)
         else
           result = backend.translate(locale, key, options)
-          if RUBY19 && result.is_a?(String)
+          if result.is_a?(String)
            result = result.dup if result.frozen?
            result.force_encoding("UTF-8")
           else


### PR DESCRIPTION
From discussion in https://github.com/grosser/gettext_i18n_rails/pull/196