### PR TITLE
Drop ruby_parser and sexp_processor dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,14 +174,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby_parser (3.20.1)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.17.0)
     singleton (0.1.1)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
-    sqlite3 (1.4.4)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     temple (0.8.2)
     text (1.3.1)
     thor (1.2.2)
@@ -209,10 +208,8 @@ DEPENDENCIES
   rails
   rake
   rspec
-  ruby_parser (>= 3.7.1)
-  sexp_processor
   slim
-  sqlite3
+  sqlite3 (~> 1.7)
 
 BUNDLED WITH
    2.4.13

--- a/Readme.md
+++ b/Readme.md
@@ -19,12 +19,10 @@ gem 'gettext_i18n_rails'
 
 ##### Optional:
 Add `gettext` if you want to find translations or build .mo files<br/>
-Add `ruby_parser` if you want to find translations inside haml/slim files
 
 ```Ruby
 # Gemfile
 gem 'gettext', '>=3.0.2', :require => false
-gem 'ruby_parser', :require => false, :group => :development
 ```
 
 ###### Add first language:

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -83,7 +83,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
-    nio4r (2.5.8)
+    nio4r (2.7.3)
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -133,9 +133,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby_parser (3.19.1)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.16.1)
     singleton (0.1.1)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
@@ -147,7 +144,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     temple (0.8.2)
     text (1.3.1)
     thor (1.2.1)
@@ -161,6 +159,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -172,10 +171,8 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rake
   rspec
-  ruby_parser (>= 3.7.1)
-  sexp_processor
   slim
-  sqlite3
+  sqlite3 (~> 1.7)
 
 BUNDLED WITH
    2.4.3

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -114,7 +114,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.3)
     nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
@@ -169,9 +169,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby_parser (3.20.1)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.17.0)
     singleton (0.1.1)
     slim (5.1.1)
       temple (~> 0.10.0)
@@ -183,9 +180,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3-arm64-darwin)
-    sqlite3 (1.6.3-x86_64-darwin)
-    sqlite3 (1.6.3-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     temple (0.10.2)
     text (1.3.1)
     thor (1.2.2)
@@ -200,6 +197,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 
@@ -212,10 +210,8 @@ DEPENDENCIES
   rails (~> 6.1.0)
   rake
   rspec
-  ruby_parser (>= 3.7.1)
-  sexp_processor
   slim
-  sqlite3
+  sqlite3 (~> 1.7)
 
 BUNDLED WITH
    2.4.13

--- a/gemfiles/rails70.gemfile.lock
+++ b/gemfiles/rails70.gemfile.lock
@@ -120,7 +120,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.3)
     nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
@@ -175,16 +175,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby_parser (3.20.1)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.17.0)
     singleton (0.1.1)
     slim (5.1.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
-    sqlite3 (1.6.3-arm64-darwin)
-    sqlite3 (1.6.3-x86_64-darwin)
-    sqlite3 (1.6.3-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     temple (0.10.2)
     text (1.3.1)
     thor (1.2.2)
@@ -199,6 +196,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 
@@ -211,10 +209,8 @@ DEPENDENCIES
   rails (~> 7.0.0)
   rake
   rspec
-  ruby_parser (>= 3.7.1)
-  sexp_processor
   slim
-  sqlite3
+  sqlite3 (~> 1.7)
 
 BUNDLED WITH
    2.4.13

--- a/gemfiles/rails71.gemfile.lock
+++ b/gemfiles/rails71.gemfile.lock
@@ -140,6 +140,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.15.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.6-x86_64-linux)
       racc (~> 1.4)
     prime (0.1.2)
@@ -203,14 +205,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    ruby_parser (3.21.1)
-      racc (~> 1.5)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.17.2)
     singleton (0.2.0)
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
+    sqlite3 (1.6.9-arm64-darwin)
     sqlite3 (1.6.9-x86_64-linux)
     stringio (3.1.1)
     temple (0.10.3)
@@ -227,6 +226,7 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -238,8 +238,6 @@ DEPENDENCIES
   rails (~> 7.1.0)
   rake
   rspec
-  ruby_parser (>= 3.7.1)
-  sexp_processor
   slim
   sqlite3 (~> 1.6.3)
 

--- a/gettext_i18n_rails.gemspec
+++ b/gettext_i18n_rails.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new name, GettextI18nRails::VERSION do |s|
   s.add_development_dependency "hamlit"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails"
-  s.add_development_dependency "ruby_parser", ">= 3.7.1" # sync with lib/gettext_i18n_rails/ruby_gettext_extractor.rb
-  s.add_development_dependency "sexp_processor"
   s.add_development_dependency "rspec"
   s.add_development_dependency "slim"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.7"
 end


### PR DESCRIPTION
After the ruby_parser code was removed in #201, there were a few remnants, including these dev dependencies.

Note that this commit also updates nio4r and sqlite3 as I couldn't get those older gem version to compile on my machine.