### PR TITLE
Make API more consistent as discussed in #207

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@
   pairs, so model name plurals (`model_name.human(count:)`) can be translated via
   `msgid_plural`. Re-extract to pick up the plural entries. See #207.
 
+### Upgrading model name msgids (#207)
+
+Up to version 2.1.0 model names were looked up by their humanized form (`_('Big car')`),
+while attributes already used the raw class name (`_('BigCar|Wheels size')`). Model names
+now also use the raw class name (`_('BigCar')`, `_('Admin::User')`), so name and attribute
+lookups are consistent and greppable.
+
+The old humanized msgid is still looked up as a fallback and prints a one-time deprecation
+warning. To migrate:
+
+ - re-run `rake gettext:store_model_attributes` and `rake gettext:find`
+ - rename the affected `msgid`s in your `*.po` files (`Big car` -> `BigCar`)
+
+The humanized fallback will be removed in a future major release.
+
+Model names are now extracted as `n_()` singular/plural pairs, so a translated
+`model_name.human(count:)` needs the `msgid_plural` filled in your `*.po` files.
+
 ## 2.1.0
 
 - Add automatic reloading of .po and .mo files in development mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Model name msgids now use the raw class name (`BigCar`, `Admin::User`) instead of the
   humanized form (`Big car`), matching `human_attribute_name`. The humanized form is still
   looked up as a deprecated fallback and warns once per msgid. See #207.
+- `rake gettext:store_model_attributes` now emits model names as `n_()` singular/plural
+  pairs, so model name plurals (`model_name.human(count:)`) can be translated via
+  `msgid_plural`. Re-extract to pick up the plural entries. See #207.
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Model name msgids now use the raw class name (`BigCar`, `Admin::User`) instead of the
+  humanized form (`Big car`), matching `human_attribute_name`. The humanized form is still
+  looked up as a deprecated fallback and warns once per msgid. See #207.
+
 ## 2.1.0
 
 - Add automatic reloading of .po and .mo files in development mode

--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,9 @@ warning. To migrate:
 
 The humanized fallback will be removed in a future major release.
 
+Model names are now extracted as `n_()` singular/plural pairs, so a translated
+`model_name.human(count:)` needs the `msgid_plural` filled in your `*.po` files.
+
 Error messages can be translated through FastGettext, if the ':message' is a translation-id or the matching Rails I18n key is translated.
 
 #### Option A:

--- a/Readme.md
+++ b/Readme.md
@@ -156,11 +156,26 @@ ActiveRecord - error messages
 =============================
 ActiveRecord error messages are translated through Rails::I18n, but
 model names and model attributes are translated through FastGettext.
-Therefore a validation error on a BigCar's wheels_size needs `_('big car')` and `_('BigCar|Wheels size')`
+Therefore a validation error on a BigCar's wheels_size needs `_('BigCar')` and `_('BigCar|Wheels size')`
 to display localized.
 
 The model/attribute translations can be found through `rake gettext:store_model_attributes`,
 (which ignores some commonly untranslated columns like id,type,xxx_count,...).
+
+#### Upgrading model name msgids
+
+Up to version 2.1.0 model names were looked up by their humanized form (`_('Big car')`),
+while attributes already used the raw class name (`_('BigCar|Wheels size')`). Model names
+now also use the raw class name (`_('BigCar')`, `_('Admin::User')`), so name and attribute
+lookups are consistent and greppable.
+
+The old humanized msgid is still looked up as a fallback and prints a one-time deprecation
+warning. To migrate:
+
+ - re-run `rake gettext:store_model_attributes` and `rake gettext:find`
+ - rename the affected `msgid`s in your `*.po` files (`Big car` -> `BigCar`)
+
+The humanized fallback will be removed in a future major release.
 
 Error messages can be translated through FastGettext, if the ':message' is a translation-id or the matching Rails I18n key is translated.
 

--- a/Readme.md
+++ b/Readme.md
@@ -162,24 +162,6 @@ to display localized.
 The model/attribute translations can be found through `rake gettext:store_model_attributes`,
 (which ignores some commonly untranslated columns like id,type,xxx_count,...).
 
-#### Upgrading model name msgids
-
-Up to version 2.1.0 model names were looked up by their humanized form (`_('Big car')`),
-while attributes already used the raw class name (`_('BigCar|Wheels size')`). Model names
-now also use the raw class name (`_('BigCar')`, `_('Admin::User')`), so name and attribute
-lookups are consistent and greppable.
-
-The old humanized msgid is still looked up as a fallback and prints a one-time deprecation
-warning. To migrate:
-
- - re-run `rake gettext:store_model_attributes` and `rake gettext:find`
- - rename the affected `msgid`s in your `*.po` files (`Big car` -> `BigCar`)
-
-The humanized fallback will be removed in a future major release.
-
-Model names are now extracted as `n_()` singular/plural pairs, so a translated
-`model_name.human(count:)` needs the `msgid_plural` filled in your `*.po` files.
-
 Error messages can be translated through FastGettext, if the ':message' is a translation-id or the matching Rails I18n key is translated.
 
 #### Option A:

--- a/lib/gettext_i18n_rails.rb
+++ b/lib/gettext_i18n_rails.rb
@@ -3,6 +3,21 @@ require 'gettext_i18n_rails/gettext_hooks'
 
 module GettextI18nRails
   IGNORE_TABLES = [/^sitemap_/, /_versions$/, 'schema_migrations', 'sessions', 'delayed_jobs']
+
+  # Issue #207: model-name msgids changed from the humanized form
+  # ("Big car") to the raw class name ("BigCar"), matching attributes.
+  # The humanized form is still looked up as a fallback; warn once per
+  # msgid so apps can migrate their .po files.
+  def self.warn_legacy_model_msgid(legacy, current)
+    @warned_legacy_model_msgids ||= {}
+    return if @warned_legacy_model_msgids.key?(legacy)
+    @warned_legacy_model_msgids[legacy] = true
+    warn(
+      "[gettext_i18n_rails] msgid #{legacy.inspect} is deprecated, " \
+      "re-extract and translate #{current.inspect} instead " \
+      "(https://github.com/grosser/gettext_i18n_rails/issues/207)"
+    )
+  end
 end
 
 # translate from everywhere

--- a/lib/gettext_i18n_rails/active_model/name.rb
+++ b/lib/gettext_i18n_rails/active_model/name.rb
@@ -1,12 +1,12 @@
 module ActiveModel
   Name.class_eval do
     def human(options={})
-      human_name = @klass.humanize_class_name
+      msgid = @klass.gettext_model_name_msgid
 
       if count = options[:count]
-        n_(human_name, human_name.pluralize, count)
+        n_(msgid, msgid.pluralize, count)
       else
-        _(human_name)
+        _(msgid)
       end
     end
   end

--- a/lib/gettext_i18n_rails/active_model/translation.rb
+++ b/lib/gettext_i18n_rails/active_model/translation.rb
@@ -52,14 +52,10 @@ module ActiveModel
     # translation -- then +legacy+ is returned and a deprecation is warned
     # once. Keeps pre-#207 .po files working during the transition.
     def gettext_resolve_legacy_msgid(current, legacy)
-      return current if current == legacy || FastGettext.cached_find(current)
+      return current if current == legacy || FastGettext.cached_find(current) || !FastGettext.cached_find(legacy)
 
-      if FastGettext.cached_find(legacy)
-        GettextI18nRails.warn_legacy_model_msgid(legacy, current)
-        legacy
-      else
-        current
-      end
+      GettextI18nRails.warn_legacy_model_msgid(legacy, current)
+      legacy
     end
   end
 end

--- a/lib/gettext_i18n_rails/active_model/translation.rb
+++ b/lib/gettext_i18n_rails/active_model/translation.rb
@@ -8,7 +8,8 @@ module ActiveModel
     def gettext_translation_for_attribute_name(attribute)
       attribute = attribute.to_s
       if attribute.end_with?('_id')
-        humanize_class_name(attribute)
+        # foreign keys share the associated model's msgid (see #207)
+        gettext_resolve_legacy_msgid(attribute.sub(/_id\z/, '').camelize, humanize_class_name(attribute))
       else
         attribute_key = attribute.split('.').map! {|a| a.humanize }.join('|')
         root = inheritance_tree_root(self).to_s
@@ -39,6 +40,26 @@ module ActiveModel
     def humanize_class_name(name=nil)
       name ||= self.to_s
       name.underscore.humanize
+    end
+
+    # Canonical msgid for a model name is the raw class name (see #207),
+    # e.g. "SomeNamespace::SomeModel" -- consistent with human_attribute_name.
+    def gettext_model_name_msgid
+      gettext_resolve_legacy_msgid(to_s, humanize_class_name)
+    end
+
+    # Returns +current+, unless only the legacy msgid resolves to a
+    # translation -- then +legacy+ is returned and a deprecation is warned
+    # once. Keeps pre-#207 .po files working during the transition.
+    def gettext_resolve_legacy_msgid(current, legacy)
+      return current if current == legacy || FastGettext.cached_find(current)
+
+      if FastGettext.cached_find(legacy)
+        GettextI18nRails.warn_legacy_model_msgid(legacy, current)
+        legacy
+      else
+        current
+      end
     end
   end
 end

--- a/lib/gettext_i18n_rails/active_record.rb
+++ b/lib/gettext_i18n_rails/active_record.rb
@@ -9,6 +9,6 @@ class ActiveRecord::Base
 
   # method deprecated in Rails 3.1
   def self.human_name(*args)
-    _(self.humanize_class_name)
+    _(gettext_model_name_msgid)
   end
 end

--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -9,12 +9,11 @@ module GettextI18nRails
       File.open(file,'w') do |f|
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
         ModelAttributesFinder.new.find(options).each do |model,column_names|
-          f.puts("_('#{model}')")
+          f.puts(gettext_extraction_call(model.to_s))
 
           #all columns namespaced under the model
           column_names.each do |attribute|
-            translation = model.gettext_translation_for_attribute_name(attribute)
-            f.puts("_('#{translation}')")
+            f.puts(gettext_extraction_call(model.gettext_translation_for_attribute_name(attribute)))
           end
         end
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
@@ -27,6 +26,18 @@ module GettextI18nRails
     end
   end
   module_function :store_model_attributes
+
+  # Model-name msgids (no '|') are emitted as an n_() singular/plural pair, so the
+  # .po file carries msgid_plural for `model_name.human(count:)`. Attribute msgids
+  # (scoped with '|') have no plural form and stay singular. See issue #207.
+  def gettext_extraction_call(msgid)
+    if msgid.include?('|')
+      "_('#{msgid}')"
+    else
+      "n_('#{msgid}', '#{msgid.pluralize}')"
+    end
+  end
+  module_function :gettext_extraction_call
 
   class ModelAttributesFinder
     # options:

--- a/lib/gettext_i18n_rails/model_attributes_finder.rb
+++ b/lib/gettext_i18n_rails/model_attributes_finder.rb
@@ -9,7 +9,7 @@ module GettextI18nRails
       File.open(file,'w') do |f|
         f.puts "#DO NOT MODIFY! AUTOMATICALLY GENERATED FILE!"
         ModelAttributesFinder.new.find(options).each do |model,column_names|
-          f.puts("_('#{model.humanize_class_name}')")
+          f.puts("_('#{model}')")
 
           #all columns namespaced under the model
           column_names.each do |attribute|

--- a/spec/gettext_i18n_rails/active_model/name_spec.rb
+++ b/spec/gettext_i18n_rails/active_model/name_spec.rb
@@ -10,16 +10,22 @@ if ActiveRecord::VERSION::MAJOR >= 3
     end
 
     describe '#human' do
-      it "is translated through FastGettext" do
+      it "is translated through FastGettext using the raw class name" do
         name = ActiveModel::Name.new(CarSeat)
-        name.should_receive(:_).with('Car seat').and_return('Autositz')
+        name.should_receive(:_).with('CarSeat').and_return('Autositz')
         name.human.should == 'Autositz'
       end
 
       it "is translated through FastGettext in plural form" do
         name = ActiveModel::Name.new(CarSeat)
-        name.should_receive(:n_).with('Car seat', 'Car seats', 2).and_return('Сиденья')
+        name.should_receive(:n_).with('CarSeat', 'CarSeats', 2).and_return('Сиденья')
         name.human(count: 2).should == 'Сиденья'
+      end
+
+      it "falls back to the legacy humanized msgid" do
+        FastGettext.stub(:current_repository).and_return('Car seat' => 'Autositz')
+        GettextI18nRails.stub(:warn_legacy_model_msgid)
+        ActiveModel::Name.new(CarSeat).human.should == 'Autositz'
       end
     end
   end

--- a/spec/gettext_i18n_rails/active_record_spec.rb
+++ b/spec/gettext_i18n_rails/active_record_spec.rb
@@ -7,9 +7,21 @@ describe ActiveRecord::Base do
   end
 
   describe :human_name do
-    it "is translated through FastGettext" do
-      CarSeat.should_receive(:_).with('Car seat').and_return('Autositz')
+    it "is translated through FastGettext using the raw class name" do
+      CarSeat.should_receive(:_).with('CarSeat').and_return('Autositz')
       CarSeat.human_name.should == 'Autositz'
+    end
+  end
+
+  describe :gettext_model_name_msgid do
+    it "uses the raw class name" do
+      CarSeat.gettext_model_name_msgid.should == 'CarSeat'
+    end
+
+    it "falls back to the legacy humanized msgid and warns" do
+      FastGettext.stub(:current_repository).and_return('Car seat' => 'Autositz')
+      GettextI18nRails.should_receive(:warn_legacy_model_msgid).with('Car seat', 'CarSeat')
+      CarSeat.gettext_model_name_msgid.should == 'Car seat'
     end
   end
 
@@ -36,7 +48,13 @@ describe ActiveRecord::Base do
   end
 
   describe :gettext_translation_for_attribute_name do
-    it "translates foreign keys to model name keys" do
+    it "translates foreign keys to the raw model name key" do
+      Part.gettext_translation_for_attribute_name(:car_seat_id).should == 'CarSeat'
+    end
+
+    it "falls back to the legacy humanized foreign key msgid" do
+      FastGettext.stub(:current_repository).and_return('Car seat' => 'Autositz')
+      GettextI18nRails.stub(:warn_legacy_model_msgid)
       Part.gettext_translation_for_attribute_name(:car_seat_id).should == 'Car seat'
     end
   end

--- a/spec/gettext_i18n_rails/model_attributes_finder_spec.rb
+++ b/spec/gettext_i18n_rails/model_attributes_finder_spec.rb
@@ -17,6 +17,20 @@ describe GettextI18nRails::ModelAttributesFinder do
   # Rails < 3.0 doesn't have DescendantsTracker.
   # Instead of iterating over ObjectSpace (slow) the decision was made NOT to support
   # class hierarchies with abstract base classes in Rails 2.x
+  describe ".store_model_attributes" do
+    it "emits model names as n_() plural pairs and attributes as _()" do
+      FastGettext.silence_errors
+      content = with_file('') do |path|
+        GettextI18nRails.store_model_attributes(:to => path, :ignore_columns => [/_id$/, 'id', 'type'])
+        File.read(path)
+      end
+      content.should include("n_('CarSeat', 'CarSeats')")
+      content.should include("n_('Part', 'Parts')")
+      content.should include("_('CarSeat|Seat color')")
+      content.should_not include("_('CarSeat')")
+    end
+  end
+
   describe "#find" do
     it "returns all AR models" do
       keys = finder.find({}).keys


### PR DESCRIPTION
Closes #207 

Closes #207.

`model_name.human` looked up the humanized class name (`Big car`) while
`human_attribute_name` used the raw class name (`BigCar|...`). This makes
them consistent on the raw form, per discussion in #207.

### Commit 1 — raw model name msgids
- `model_name.human` / `human_name` now look up `_('BigCar')`,
  `_('Admin::User')` instead of `_('Big car')`.
- `_id` foreign keys resolve to the same raw model-name msgid (still
  shared with the model name).
- Backwards compatible: the legacy humanized msgid is still looked up as
  a fallback (`gettext_resolve_legacy_msgid`); a one-time deprecation
  warning is printed so apps can migrate their `.po` files.
- `store_model_attributes` extracts the raw form.

### Commit 2 — model name plurals
- `model_name.human(count:)` already calls `n_()`, but extraction only
  ever emitted `_()`, so `msgid_plural` never reached the `.po`.
- `store_model_attributes` now emits model names as `n_('BigCar',
  'BigCars')` pairs; attributes (scoped with `|`) stay singular.

### Open question
Plural of a namespaced model is `SomeNamespace::SomeModels` — not a real
constant. Acceptable given the raw-form decision, but flagging it.

Upgrade notes added to the README. Marked draft for a sanity check on
the approach before polishing.
